### PR TITLE
node status

### DIFF
--- a/pkg/mapr/DBUtils.go
+++ b/pkg/mapr/DBUtils.go
@@ -67,7 +67,7 @@ func GetAvailableNodes(clusterID string, operatingSystem string, osVersion strin
 	{"$matches":{"NodeObj.OperatingSystem.Name":"(?i)%s"}},
 	{"$lt":{"ExpiresAT": "%s"}},
 	{"$matches":{"NodeObj.OperatingSystem.Version":"%s"}},
-	{"$eq":{"Offline": %t}},
+	{"$eq":{"isOffline": %t}},
 ]}}`,
 		operatingSystem, time.Now().Format(time.RFC3339), osVersion, false)
 

--- a/pkg/mapr/DBUtils.go
+++ b/pkg/mapr/DBUtils.go
@@ -67,10 +67,9 @@ func GetAvailableNodes(clusterID string, operatingSystem string, osVersion strin
 	{"$matches":{"NodeObj.OperatingSystem.Name":"(?i)%s"}},
 	{"$lt":{"ExpiresAT": "%s"}},
 	{"$matches":{"NodeObj.OperatingSystem.Version":"%s"}},
-	{"$eq":{"Online": %t}},
-	{"$eq":{"Included":%t}}
+	{"$eq":{"Offline": %t}},
 ]}}`,
-		operatingSystem, time.Now().Format(time.RFC3339), osVersion, true, true)
+		operatingSystem, time.Now().Format(time.RFC3339), osVersion, false)
 
 	zap.S().Info(queryStr)
 

--- a/pkg/models/Models.go
+++ b/pkg/models/Models.go
@@ -19,6 +19,8 @@ type NodeDBJson struct {
 	NodeObj   Node
 	ClusterID string
 	ExpiresAT string
+	Online    bool
+	Included  bool
 }
 
 type Esxi struct {

--- a/pkg/models/Models.go
+++ b/pkg/models/Models.go
@@ -19,7 +19,7 @@ type NodeDBJson struct {
 	NodeObj   Node
 	ClusterID string
 	ExpiresAT string
-	Offline   bool
+	isOffline   bool
 	Note      string
 }
 

--- a/pkg/models/Models.go
+++ b/pkg/models/Models.go
@@ -21,6 +21,7 @@ type NodeDBJson struct {
 	ExpiresAT string
 	Online    bool
 	Included  bool
+	Note     string
 }
 
 type Esxi struct {

--- a/pkg/models/Models.go
+++ b/pkg/models/Models.go
@@ -19,9 +19,8 @@ type NodeDBJson struct {
 	NodeObj   Node
 	ClusterID string
 	ExpiresAT string
-	Online    bool
-	Included  bool
-	Note     string
+	Offline   bool
+	Note      string
 }
 
 type Esxi struct {

--- a/pkg/utils/DataImportUtils.go
+++ b/pkg/utils/DataImportUtils.go
@@ -144,7 +144,7 @@ func GetNodeJsonDocMap(node models.Node) map[string]interface{} {
 	nodeDbJson := models.NodeDBJson{
 		NodeObj: node,
 		ID:      node.ID,
-		Offline: false,
+		isOffline: false,
 	}
 
 	return structs.Map(nodeDbJson)

--- a/pkg/utils/DataImportUtils.go
+++ b/pkg/utils/DataImportUtils.go
@@ -144,8 +144,7 @@ func GetNodeJsonDocMap(node models.Node) map[string]interface{} {
 	nodeDbJson := models.NodeDBJson{
 		NodeObj: node,
 		ID:      node.ID,
-		Included: true,
-		Online: true,
+		Offline: false,
 	}
 
 	return structs.Map(nodeDbJson)

--- a/pkg/utils/DataImportUtils.go
+++ b/pkg/utils/DataImportUtils.go
@@ -144,6 +144,8 @@ func GetNodeJsonDocMap(node models.Node) map[string]interface{} {
 	nodeDbJson := models.NodeDBJson{
 		NodeObj: node,
 		ID:      node.ID,
+		Included: true,
+		Online: true,
 	}
 
 	return structs.Map(nodeDbJson)


### PR DESCRIPTION
Added Online and Included properties for the nodes. Online is node status based on ping, Included is node status based on whether this node must be unavailable for reservation for some reason or not.